### PR TITLE
Update Run-tSQLtTests.ps1 to resolve issue #12

### DIFF
--- a/buildAndReleaseTask/Invoke-tSQLtTests.ps1
+++ b/buildAndReleaseTask/Invoke-tSQLtTests.ps1
@@ -23,5 +23,5 @@ else {
     Write-Output "Tests ran successfully. Saving test results to $testResultsFileName"
 }
 
-Invoke-SqlCmd -ConnectionString $connectionString -QueryTimeout $queryTimeout -InputFile ".\GetTestResults.sql" | Select-Object -ExpandProperty XML* | Out-File -FilePath $testResultsFileName
+Invoke-SqlCmd -ConnectionString $connectionString -QueryTimeout $queryTimeout -InputFile ".\GetTestResults.sql" | Select-Object -ExpandProperty XML* | Out-File -FilePath $testResultsFileName  -NoNewline
 Write-Output "Finished gathering test results and writing it to $testResultsFileName"

--- a/buildAndReleaseTask/Run-tSQLtTests.ps1
+++ b/buildAndReleaseTask/Run-tSQLtTests.ps1
@@ -65,6 +65,7 @@ function Invoke-TestExecution {
         [Parameter(Mandatory=$true)]
         [string]$runAllTests,
         [Parameter(Mandatory=$true)]
+        [AllowEmptyString()]
         [string]$testOrClassName,
         [Parameter(Mandatory=$true)]
         [string]$connectionString,
@@ -98,6 +99,7 @@ function Invoke-TestExecutionWithCodeCoverage {
         [Parameter(Mandatory=$true)]
         [string]$runAllTests,
         [Parameter(Mandatory=$true)]
+        [AllowEmptyString()]
         [string]$testOrClassName,
         [Parameter(Mandatory=$true)]
         [string]$connectionString,


### PR DESCRIPTION
Allow empty string for the $testOrClassName parameter of the Invoke-TestExecutionWithCodeCoverage and Invoke-TestExecution functions to resolve issue #12