### PR TITLE
Fix for issue #13

### DIFF
--- a/buildAndReleaseTask/Invoke-tSQLtTests.ps1
+++ b/buildAndReleaseTask/Invoke-tSQLtTests.ps1
@@ -23,5 +23,5 @@ else {
     Write-Output "Tests ran successfully. Saving test results to $testResultsFileName"
 }
 
-Invoke-SqlCmd -ConnectionString $connectionString -QueryTimeout $queryTimeout -InputFile ".\GetTestResults.sql" | Select-Object -ExpandProperty XML* | Out-File -FilePath $testResultsFileName
+Invoke-SqlCmd -ConnectionString $connectionString -QueryTimeout $queryTimeout -InputFile ".\GetTestResults.sql" | Select-Object -ExpandProperty XML* | Out-File -FilePath $testResultsFileName -NoNewLine
 Write-Output "Finished gathering test results and writing it to $testResultsFileName"


### PR DESCRIPTION
Add -NoNewLine argument to Out-File to prevent new line characters from being inserted every 2033 characters.  These extra new line characters can break the XML output of the file in some cases.  For example if the new line is inserted inside an XML element tag.