### PR TITLE
changing patch version to 5 so azure devops picks up previous bug fixes

### DIFF
--- a/buildAndReleaseTask/task.json
+++ b/buildAndReleaseTask/task.json
@@ -11,7 +11,7 @@
     "version": {
         "Major": 0,
         "Minor": 2,
-        "Patch": 3
+        "Patch": 5
     },
     "instanceNameFormat": "Run tSQlt Unit Tests",
     "groups": [


### PR DESCRIPTION
@ricardoserradas Azure devops still uses the older versions of the repo, this means that we are still creating invalid XML when outputing TestResults. 

(this fixes #18 )
